### PR TITLE
Changed 'Viewer resized to...' log msg from 'info' to 'trace' level

### DIFF
--- a/qtfx/QOsgViewer.cpp
+++ b/qtfx/QOsgViewer.cpp
@@ -227,7 +227,7 @@ bool QOsgViewer::handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
 	{
 		width_ = ea.getWindowWidth();
 		height_ = ea.getWindowHeight();
-		xo::log::info( "Viewer resized to ", width_, "x", height_ );
+		xo::log::trace( "Viewer resized to ", width_, "x", height_ );
 		updateHudPos();
 		return true;
 	}


### PR DESCRIPTION
Ignore this PR if you don't agree (which would be fine by me): I just noticed that SCONE's log UI window gets spammed whenever I adjust the window (which also happens if I use an OS keybind like `OSKey+<left/right/up>`